### PR TITLE
chore: config coverage with jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,40 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			
+			<!-- JaCoCo plugin for test coverage -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<!-- Configure Surefire plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.5.3</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.java</include>
+					</includes>
+					<useModulePath>false</useModulePath>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/com/delimce/aibroker/domain/exceptions/SecurityValidationExceptionTest.java
+++ b/src/test/java/com/delimce/aibroker/domain/exceptions/SecurityValidationExceptionTest.java
@@ -1,0 +1,51 @@
+package com.delimce.aibroker.domain.exceptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class SecurityValidationExceptionTest {
+
+    // Concrete implementation of SecurityValidationException for testing
+    private static class TestSecurityValidationException extends SecurityValidationException {
+        public TestSecurityValidationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    @Test
+    void shouldStoreMessageAndCause() {
+        // Arrange
+        String errorMessage = "Security validation failed";
+        Exception cause = new RuntimeException("Root cause");
+        
+        // Act
+        SecurityValidationException exception = new TestSecurityValidationException(errorMessage, cause);
+        
+        // Assert
+        assertEquals(errorMessage, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+    
+    @Test
+    void shouldExtendThrowable() {
+        // Arrange & Act
+        SecurityValidationException exception = new TestSecurityValidationException("test", null);
+        
+        // Assert
+        assertTrue(exception instanceof Throwable);
+    }
+    
+    @Test
+    void shouldAllowNullCause() {
+        // Arrange
+        String errorMessage = "Security error";
+        
+        // Act
+        SecurityValidationException exception = new TestSecurityValidationException(errorMessage, null);
+        
+        // Assert
+        assertEquals(errorMessage, exception.getMessage());
+        assertNull(exception.getCause());
+    }
+}

--- a/src/test/java/com/delimce/aibroker/domain/exceptions/security/JwtTokenExceptionTest.java
+++ b/src/test/java/com/delimce/aibroker/domain/exceptions/security/JwtTokenExceptionTest.java
@@ -1,0 +1,54 @@
+package com.delimce.aibroker.domain.exceptions.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.delimce.aibroker.domain.exceptions.SecurityValidationException;
+
+public class JwtTokenExceptionTest {
+
+    @Test
+    void shouldBeInstanceOfSecurityValidationException() {
+        // Arrange & Act
+        JwtTokenException exception = new JwtTokenException();
+        
+        // Assert
+        assertTrue(exception instanceof SecurityValidationException);
+    }
+    
+    @Test
+    void shouldUseDefaultMessageWhenNoMessageProvided() {
+        // Arrange & Act
+        JwtTokenException exception = new JwtTokenException();
+        
+        // Assert
+        assertEquals("Invalid or expired JWT token", exception.getMessage());
+    }
+    
+    @Test
+    void shouldUseProvidedMessage() {
+        // Arrange
+        String customMessage = "Custom error message";
+        
+        // Act
+        JwtTokenException exception = new JwtTokenException(customMessage);
+        
+        // Assert
+        assertEquals(customMessage, exception.getMessage());
+    }
+    
+    @Test
+    void shouldStoreProvidedCause() {
+        // Arrange
+        String customMessage = "Custom error message";
+        Throwable cause = new RuntimeException("Original cause");
+        
+        // Act
+        JwtTokenException exception = new JwtTokenException(customMessage, cause);
+        
+        // Assert
+        assertEquals(customMessage, exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+}


### PR DESCRIPTION
This pull request introduces improvements to the build process by adding plugins for test coverage and test execution, as well as new unit tests for exception handling in the application. The most important changes include the addition of the JaCoCo and Surefire plugins to `pom.xml` and the creation of unit tests for `SecurityValidationException` and `JwtTokenException`.

### Build Process Enhancements:
* Added the JaCoCo Maven plugin to `pom.xml` for generating test coverage reports. This includes configurations for preparing the agent and generating reports during the `test` phase.
* Added the Maven Surefire plugin to `pom.xml` to configure and execute unit tests, including specifying test file patterns and disabling the module path.

### Unit Testing Improvements:
* Created `SecurityValidationExceptionTest` to validate the behavior of `SecurityValidationException`, including tests for storing messages and causes, extending `Throwable`, and handling null causes.
* Created `JwtTokenExceptionTest` to test `JwtTokenException`, ensuring it behaves as a subclass of `SecurityValidationException`, uses default and custom messages correctly, and stores provided causes.